### PR TITLE
Remove mask_punctuation with ids assert

### DIFF
--- a/colbert/modeling/inference.py
+++ b/colbert/modeling/inference.py
@@ -69,9 +69,6 @@ class ModelInference():
             D = [d for batch in batches for d in batch]
             #print("lenD = %d " % len(D))
             if with_ids:
-                #the masking code assumes that args.mask_punctuation is false.
-                assert len(self.colbert.skiplist) == 0
-
                 D_i = [ d[(mask > 0) & (d != 0)] for input_ids, attention_masks in batch_ids for d, mask in zip(input_ids,attention_masks) ]
 
                 if DEBUG:

--- a/colbert/modeling/inference.py
+++ b/colbert/modeling/inference.py
@@ -70,6 +70,9 @@ class ModelInference():
             #print("lenD = %d " % len(D))
             if with_ids:
                 D_i = [ d[(mask > 0) & (d != 0)] for input_ids, attention_masks in batch_ids for d, mask in zip(input_ids,attention_masks) ]
+                # remove skiplist tokens from ids
+                if len(self.colbert.skiplist) > 0:
+                    D_i = [d[[token not in self.colbert.skiplist for token in d.tolist()]] for d in D_i]
 
                 if DEBUG:
                     docid=-1


### PR DESCRIPTION
Removes the assert that blocks the docFromText function when run with mask_punctuation=True and with_ids=True